### PR TITLE
Fixed json formatting so translation will load

### DIFF
--- a/public/locales/en/delegate.json
+++ b/public/locales/en/delegate.json
@@ -5,5 +5,5 @@
     "info": "Grant control to another Solana account to use Mango on your behalf.",
     "public-key": "Delegate Public Key",
     "delegate-updated": "Delegate Updated",
-    "set-error": "Could not set Delegate",
+    "set-error": "Could not set Delegate"
 }


### PR DESCRIPTION
There was an extra comma  (invalid JSON format) in delegate.json, which prevented React i18next from parsing the locale file.

![mango-locale](https://user-images.githubusercontent.com/79712764/165000147-2e638274-0ed1-41ff-9f76-e5b00ea0ed95.png)

PR Requirements:

- [ ] Summarize changes
- [ ] Included a screenshot, if applicable
- [ ] Test on mobile
- [ ] Request at least one reviewer
